### PR TITLE
Fix for incorrect working timeout

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -49,7 +49,7 @@
 import Domoticz
 import json
 import os.path
-
+from threading import Thread
 import wideq
 
 
@@ -82,6 +82,7 @@ class BasePlugin:
 
         self.lg_device = None
         self.state = {}
+        self.hbtActive = False
 
     def onStart(self):
         # these variables definitions has to be here (onStart)
@@ -327,59 +328,64 @@ class BasePlugin:
     def onDisconnect(self, Connection):
         Domoticz.Log("onDisconnect called")
 
-    # every 5 seconds
+    # every 10 seconds
     def onHeartbeat(self):
         # Domoticz.Log("onHeartbeat called: "+str(self.heartbeat_counter))
-        if (self.heartbeat_counter % 6) == 0:
+        if self.heartbeat_counter == 0:
             # Domoticz.Log("onHeartbeat %6 called: "+str(self.heartbeat_counter))
             # import web_pdb; web_pdb.set_trace()
             # to check if self.lg_device has been already read out from server
             if self.lg_device is not None:
-        
-                try:
-                    self.lg_device_status = self.lg_device.get_status()
-                    
-                    # AC part
-                    if self.DEVICE_TYPE == "type_ac":
-                        self.operation = self.lg_device_status.is_on
-                        if self.operation:
-                            self.operation = 1
-                        else:
-                            self.operation = 0
-                            
-                        self.op_mode = self.lg_device_status.mode.name
-                        self.target_temp = str(self.lg_device_status.temp_cfg_c)
-                        self.room_temp = str(self.lg_device_status.temp_cur_c)
-                        self.wind_strength = self.lg_device_status.fan_speed.name
-                        self.h_step = self.lg_device_status.horz_swing.name
-                        self.v_step = self.lg_device_status.vert_swing.name
-                        # self.power = str(self.lg_device_status.energy_on_current)
-                        
-                    # AWHP part
-                    if self.DEVICE_TYPE == "type_awhp":
-                        self.operation = self.lg_device_status.is_on
-                        if self.operation:
-                            self.operation = 1
-                        else:
-                            self.operation = 0
-                            
-                        self.op_mode = self.lg_device_status.mode.name
-                        self.target_temp = str(self.lg_device_status.temp_cfg_c)
-                        self.hot_water_temp = str(self.lg_device_status.temp_hot_water_cfg_c)
-                        self.in_water_temp = str(self.lg_device_status.in_water_cur_c)
-                        self.out_water_temp = str(self.lg_device_status.out_water_cur_c)
-                        
-                    self.update_domoticz()
-                        
-                except wideq.NotLoggedInError:
-            
-                    # read AC parameters and Client state
-                    self.lg_device = self.wideq_object.operate_device(device_id=self.DEVICE_ID)
+                if not self.hbtActive:
+                    Thread(target=self.heartbeatThread, args=None)
                             
         self.heartbeat_counter = self.heartbeat_counter + 1
-        if self.heartbeat_counter > 6:
+        if self.heartbeat_counter > 9:
             self.heartbeat_counter = 0
-        
+
+    def heartbeatThread(self):
+        self.hbtActive = True
+        try:
+            self.lg_device_status = self.lg_device.get_status()
+            
+            # AC part
+            if self.DEVICE_TYPE == "type_ac":
+                self.operation = self.lg_device_status.is_on
+                if self.operation:
+                    self.operation = 1
+                else:
+                    self.operation = 0
+                    
+                self.op_mode = self.lg_device_status.mode.name
+                self.target_temp = str(self.lg_device_status.temp_cfg_c)
+                self.room_temp = str(self.lg_device_status.temp_cur_c)
+                self.wind_strength = self.lg_device_status.fan_speed.name
+                self.h_step = self.lg_device_status.horz_swing.name
+                self.v_step = self.lg_device_status.vert_swing.name
+                # self.power = str(self.lg_device_status.energy_on_current)
+                
+            # AWHP part
+            if self.DEVICE_TYPE == "type_awhp":
+                self.operation = self.lg_device_status.is_on
+                if self.operation:
+                    self.operation = 1
+                else:
+                    self.operation = 0
+                    
+                self.op_mode = self.lg_device_status.mode.name
+                self.target_temp = str(self.lg_device_status.temp_cfg_c)
+                self.hot_water_temp = str(self.lg_device_status.temp_hot_water_cfg_c)
+                self.in_water_temp = str(self.lg_device_status.in_water_cur_c)
+                self.out_water_temp = str(self.lg_device_status.out_water_cur_c)
+                
+            self.update_domoticz()
+                
+        except wideq.NotLoggedInError:
+    
+            # read AC parameters and Client state
+            self.lg_device = self.wideq_object.operate_device(device_id=self.DEVICE_ID)
+        self.hbtActive = False
+         
     def update_domoticz(self):
         # import web_pdb; web_pdb.set_trace()
         # AC part


### PR DESCRIPTION
The timeout for heartbeat is not working properly. The timeout it self is 6 seconds and the requests are handled when the counter is 0 and 6. Which causes 2 requests after each other (within 2 seconds).
Also When the request takes to long domoticz will kill the thread.
To prevent that the request is now placed in its own thread and only called again when it is finished.
Personally I set the poll timeout to 10 seconds.